### PR TITLE
Clown ruin without staff

### DIFF
--- a/_maps/RandomRuins/LavaRuins/lavaland_biodome_clown_temple.dmm
+++ b/_maps/RandomRuins/LavaRuins/lavaland_biodome_clown_temple.dmm
@@ -1,0 +1,151 @@
+"aa" = (/turf/template_noop,/area/template_noop)
+"ab" = (/obj/effect/mapping_helpers/no_lava,/turf/open/floor/plating/asteroid/basalt/lava_land_surface,/area/lavaland/surface/outdoors/explored)
+"ac" = (/obj/effect/mapping_helpers/no_lava,/turf/open/floor/noslip{initial_gas_mix = "o2=14;n2=23;TEMP=300"},/area/lavaland/surface/outdoors/explored)
+"ad" = (/obj/effect/mapping_helpers/no_lava,/mob/living/simple_animal/hostile/retaliate/clown,/turf/open/floor/plating/asteroid/basalt/lava_land_surface,/area/lavaland/surface/outdoors/explored)
+"ae" = (/obj/machinery/light,/obj/effect/mapping_helpers/no_lava,/turf/open/floor/plating/asteroid/basalt/lava_land_surface,/area/ruin/powered/clownplanet)
+"af" = (/obj/item/clothing/head/cone,/obj/effect/mapping_helpers/no_lava,/turf/open/floor/noslip{initial_gas_mix = "o2=14;n2=23;TEMP=300"},/area/lavaland/surface/outdoors/explored)
+"ag" = (/obj/item/paper/crumpled/bloody/ruins/lavaland/clown_planet/hope,/obj/effect/decal/cleanable/blood/old,/obj/effect/mapping_helpers/no_lava,/turf/open/floor/noslip{initial_gas_mix = "o2=14;n2=23;TEMP=300"},/area/lavaland/surface/outdoors/explored)
+"ah" = (/turf/closed/wall/r_wall,/area/ruin/powered/clownplanet)
+"ai" = (/obj/machinery/disposal/deliveryChute{desc = "The following is engraved upon the chute: A FATE WORSE THAN DEATH LIES WITHIN"; dir = 1; name = "THE TRIAL OF HONKITUDE"},/obj/structure/disposalpipe/trunk,/obj/effect/mapping_helpers/no_lava,/turf/open/floor/noslip{initial_gas_mix = "o2=14;n2=23;TEMP=300"},/area/ruin/powered/clownplanet)
+"aj" = (/obj/machinery/light/small,/obj/effect/mapping_helpers/no_lava,/turf/open/floor/noslip{initial_gas_mix = "o2=14;n2=23;TEMP=300"},/area/ruin/powered/clownplanet)
+"ak" = (/obj/structure/disposalpipe/trunk,/obj/structure/disposaloutlet{dir = 1},/obj/effect/mapping_helpers/no_lava,/turf/open/floor/noslip{initial_gas_mix = "o2=14;n2=23;TEMP=300"},/area/ruin/powered/clownplanet)
+"al" = (/turf/open/lava/smooth,/area/ruin/powered/clownplanet)
+"am" = (/obj/structure/disposalpipe/segment{invisibility = 101},/turf/closed/wall/r_wall,/area/ruin/powered/clownplanet)
+"an" = (/obj/structure/disposalpipe/segment{dir = 6},/turf/closed/wall/r_wall,/area/ruin/powered/clownplanet)
+"ao" = (/obj/structure/disposalpipe/segment{dir = 10},/turf/closed/wall/r_wall,/area/ruin/powered/clownplanet)
+"ap" = (/obj/structure/disposalpipe/segment{dir = 6},/turf/open/floor/plating,/area/ruin/powered/clownplanet)
+"aq" = (/obj/structure/disposalpipe/segment{dir = 10},/turf/open/floor/plating,/area/ruin/powered/clownplanet)
+"ar" = (/obj/structure/disposalpipe/trunk,/obj/structure/disposaloutlet{dir = 1},/turf/open/floor/plating,/area/ruin/powered/clownplanet)
+"as" = (/obj/structure/disposalpipe/segment{invisibility = 101},/obj/effect/turf_decal/tile/yellow,/obj/effect/turf_decal/tile/yellow{dir = 1},/obj/effect/turf_decal/tile/yellow{dir = 8},/obj/effect/turf_decal/tile/yellow{dir = 4},/turf/open/indestructible{icon_state = "darkfull"; wet = 8},/area/ruin/powered/clownplanet)
+"at" = (/obj/effect/mob_spawn/human/corpse/damaged,/obj/effect/decal/cleanable/blood/old,/obj/structure/disposalpipe/segment{invisibility = 101},/obj/effect/turf_decal/tile/yellow,/obj/effect/turf_decal/tile/yellow{dir = 1},/obj/effect/turf_decal/tile/yellow{dir = 8},/obj/effect/turf_decal/tile/yellow{dir = 4},/turf/open/indestructible{icon_state = "darkfull"; wet = 8},/area/ruin/powered/clownplanet)
+"au" = (/obj/structure/disposalpipe/segment{dir = 6},/obj/effect/turf_decal/tile/yellow,/obj/effect/turf_decal/tile/yellow{dir = 1},/obj/effect/turf_decal/tile/yellow{dir = 8},/obj/effect/turf_decal/tile/yellow{dir = 4},/turf/open/indestructible{icon_state = "darkfull"; wet = 8},/area/ruin/powered/clownplanet)
+"av" = (/obj/structure/disposalpipe/segment{invisibility = 101},/turf/open/floor/plating,/area/ruin/powered/clownplanet)
+"aw" = (/obj/structure/disposalpipe/sorting/mail/flip{dir = 1; sortType = 3},/turf/closed/wall/r_wall,/area/ruin/powered/clownplanet)
+"ax" = (/obj/structure/window/reinforced,/obj/structure/disposalpipe/segment{invisibility = 101},/turf/open/floor/plating,/area/ruin/powered/clownplanet)
+"ay" = (/obj/effect/decal/cleanable/pie_smudge,/obj/structure/disposalpipe/segment{invisibility = 101},/obj/effect/turf_decal/tile/yellow,/obj/effect/turf_decal/tile/yellow{dir = 1},/obj/effect/turf_decal/tile/yellow{dir = 8},/obj/effect/turf_decal/tile/yellow{dir = 4},/turf/open/indestructible{icon_state = "darkfull"; wet = 8},/area/ruin/powered/clownplanet)
+"az" = (/obj/structure/disposalpipe/segment{invisibility = 101},/obj/machinery/light/small{dir = 1},/obj/effect/turf_decal/tile/yellow,/obj/effect/turf_decal/tile/yellow{dir = 1},/obj/effect/turf_decal/tile/yellow{dir = 8},/obj/effect/turf_decal/tile/yellow{dir = 4},/turf/open/indestructible{icon_state = "darkfull"; wet = 8},/area/ruin/powered/clownplanet)
+"aA" = (/obj/structure/disposalpipe/segment{dir = 5},/obj/effect/decal/cleanable/dirt,/obj/effect/turf_decal/tile/yellow,/obj/effect/turf_decal/tile/yellow{dir = 1},/obj/effect/turf_decal/tile/yellow{dir = 8},/obj/effect/turf_decal/tile/yellow{dir = 4},/turf/open/indestructible{icon_state = "darkfull"; wet = 8},/area/ruin/powered/clownplanet)
+"aB" = (/obj/structure/disposalpipe/segment{dir = 4; invisibility = 101},/obj/effect/decal/cleanable/dirt,/obj/effect/turf_decal/tile/yellow,/obj/effect/turf_decal/tile/yellow{dir = 1},/obj/effect/turf_decal/tile/yellow{dir = 8},/obj/effect/turf_decal/tile/yellow{dir = 4},/turf/open/indestructible{icon_state = "darkfull"; wet = 8},/area/ruin/powered/clownplanet)
+"aC" = (/obj/structure/disposalpipe/segment{dir = 4; invisibility = 101},/obj/effect/turf_decal/tile/yellow,/obj/effect/turf_decal/tile/yellow{dir = 1},/obj/effect/turf_decal/tile/yellow{dir = 8},/obj/effect/turf_decal/tile/yellow{dir = 4},/turf/open/indestructible{icon_state = "darkfull"; wet = 8},/area/ruin/powered/clownplanet)
+"aD" = (/obj/structure/disposalpipe/segment{dir = 4; invisibility = 101},/obj/machinery/light/small{dir = 1},/obj/effect/turf_decal/tile/yellow,/obj/effect/turf_decal/tile/yellow{dir = 1},/obj/effect/turf_decal/tile/yellow{dir = 8},/obj/effect/turf_decal/tile/yellow{dir = 4},/turf/open/indestructible{icon_state = "darkfull"; wet = 8},/area/ruin/powered/clownplanet)
+"aE" = (/obj/structure/disposalpipe/segment{dir = 9},/obj/effect/turf_decal/tile/yellow,/obj/effect/turf_decal/tile/yellow{dir = 1},/obj/effect/turf_decal/tile/yellow{dir = 8},/obj/effect/turf_decal/tile/yellow{dir = 4},/turf/open/indestructible{icon_state = "darkfull"; wet = 8},/area/ruin/powered/clownplanet)
+"aF" = (/obj/effect/turf_decal/tile/yellow,/obj/effect/turf_decal/tile/yellow{dir = 1},/obj/effect/turf_decal/tile/yellow{dir = 8},/obj/effect/turf_decal/tile/yellow{dir = 4},/turf/open/indestructible{icon_state = "darkfull"; wet = 8},/area/ruin/powered/clownplanet)
+"aG" = (/obj/effect/decal/cleanable/dirt,/obj/effect/turf_decal/tile/yellow,/obj/effect/turf_decal/tile/yellow{dir = 1},/obj/effect/turf_decal/tile/yellow{dir = 8},/obj/effect/turf_decal/tile/yellow{dir = 4},/turf/open/indestructible{icon_state = "darkfull"; wet = 8},/area/ruin/powered/clownplanet)
+"aH" = (/obj/effect/decal/cleanable/cobweb{icon_state = "cobweb2"},/obj/effect/turf_decal/tile/yellow,/obj/effect/turf_decal/tile/yellow{dir = 1},/obj/effect/turf_decal/tile/yellow{dir = 8},/obj/effect/turf_decal/tile/yellow{dir = 4},/turf/open/indestructible{icon_state = "darkfull"; wet = 8},/area/ruin/powered/clownplanet)
+"aI" = (/obj/structure/disposalpipe/segment{dir = 4; invisibility = 101},/obj/effect/decal/cleanable/cobweb,/obj/effect/turf_decal/tile/yellow,/obj/effect/turf_decal/tile/yellow{dir = 1},/obj/effect/turf_decal/tile/yellow{dir = 8},/obj/effect/turf_decal/tile/yellow{dir = 4},/turf/open/indestructible{icon_state = "darkfull"; wet = 8},/area/ruin/powered/clownplanet)
+"aJ" = (/obj/structure/disposalpipe/segment{dir = 5},/obj/effect/turf_decal/tile/yellow,/obj/effect/turf_decal/tile/yellow{dir = 1},/obj/effect/turf_decal/tile/yellow{dir = 8},/obj/effect/turf_decal/tile/yellow{dir = 4},/turf/open/indestructible{icon_state = "darkfull"; wet = 8},/area/ruin/powered/clownplanet)
+"aK" = (/obj/structure/disposalpipe/segment{dir = 9},/obj/effect/decal/cleanable/dirt,/obj/effect/turf_decal/tile/yellow,/obj/effect/turf_decal/tile/yellow{dir = 1},/obj/effect/turf_decal/tile/yellow{dir = 8},/obj/effect/turf_decal/tile/yellow{dir = 4},/turf/open/indestructible{icon_state = "darkfull"; wet = 8},/area/ruin/powered/clownplanet)
+"aL" = (/obj/structure/disposalpipe/segment{dir = 5},/obj/item/bikehorn,/obj/effect/turf_decal/tile/yellow,/obj/effect/turf_decal/tile/yellow{dir = 1},/obj/effect/turf_decal/tile/yellow{dir = 8},/obj/effect/turf_decal/tile/yellow{dir = 4},/turf/open/indestructible{icon_state = "darkfull"; wet = 8},/area/ruin/powered/clownplanet)
+"aM" = (/obj/structure/disposalpipe/segment{dir = 5},/turf/closed/wall/r_wall,/area/ruin/powered/clownplanet)
+"aN" = (/obj/structure/disposalpipe/segment{dir = 4; invisibility = 101},/obj/effect/decal/cleanable/pie_smudge,/obj/effect/turf_decal/tile/yellow,/obj/effect/turf_decal/tile/yellow{dir = 1},/obj/effect/turf_decal/tile/yellow{dir = 8},/obj/effect/turf_decal/tile/yellow{dir = 4},/turf/open/indestructible{icon_state = "darkfull"; wet = 8},/area/ruin/powered/clownplanet)
+"aO" = (/obj/structure/disposalpipe/segment{dir = 4; invisibility = 101},/turf/closed/wall/r_wall,/area/ruin/powered/clownplanet)
+"aP" = (/obj/structure/disposalpipe/segment{dir = 10},/obj/effect/turf_decal/tile/yellow,/obj/effect/turf_decal/tile/yellow{dir = 1},/obj/effect/turf_decal/tile/yellow{dir = 8},/obj/effect/turf_decal/tile/yellow{dir = 4},/turf/open/indestructible{icon_state = "darkfull"; wet = 8},/area/ruin/powered/clownplanet)
+"aQ" = (/obj/item/bikehorn,/obj/structure/disposalpipe/segment{dir = 4; invisibility = 101},/obj/effect/turf_decal/tile/yellow,/obj/effect/turf_decal/tile/yellow{dir = 1},/obj/effect/turf_decal/tile/yellow{dir = 8},/obj/effect/turf_decal/tile/yellow{dir = 4},/turf/open/indestructible{icon_state = "darkfull"; wet = 8},/area/ruin/powered/clownplanet)
+"aR" = (/obj/structure/disposalpipe/segment{dir = 4; invisibility = 101},/turf/open/floor/plating,/area/ruin/powered/clownplanet)
+"aS" = (/turf/open/floor/plating,/area/ruin/powered/clownplanet)
+"aT" = (/obj/structure/disposalpipe/segment{dir = 9},/turf/open/floor/plating,/area/ruin/powered/clownplanet)
+"aU" = (/obj/effect/decal/cleanable/dirt,/obj/structure/disposalpipe/segment{invisibility = 101},/obj/effect/turf_decal/tile/yellow,/obj/effect/turf_decal/tile/yellow{dir = 1},/obj/effect/turf_decal/tile/yellow{dir = 8},/obj/effect/turf_decal/tile/yellow{dir = 4},/turf/open/indestructible{icon_state = "darkfull"; wet = 8},/area/ruin/powered/clownplanet)
+"aV" = (/obj/structure/disposalpipe/segment{dir = 10},/obj/machinery/light/small{dir = 4},/obj/effect/turf_decal/tile/yellow,/obj/effect/turf_decal/tile/yellow{dir = 1},/obj/effect/turf_decal/tile/yellow{dir = 8},/obj/effect/turf_decal/tile/yellow{dir = 4},/turf/open/indestructible{icon_state = "darkfull"; wet = 8},/area/ruin/powered/clownplanet)
+"aW" = (/obj/effect/spawner/structure/window/reinforced,/turf/open/floor/plating,/area/ruin/powered/clownplanet)
+"aX" = (/obj/structure/disposalpipe/segment{dir = 10},/obj/effect/decal/cleanable/dirt,/obj/machinery/light/small{dir = 8},/obj/effect/turf_decal/tile/yellow,/obj/effect/turf_decal/tile/yellow{dir = 1},/obj/effect/turf_decal/tile/yellow{dir = 8},/obj/effect/turf_decal/tile/yellow{dir = 4},/turf/open/indestructible{icon_state = "darkfull"; wet = 8},/area/ruin/powered/clownplanet)
+"aY" = (/obj/item/bikehorn,/obj/effect/decal/cleanable/dirt,/obj/structure/disposalpipe/segment{invisibility = 101},/obj/effect/turf_decal/tile/yellow,/obj/effect/turf_decal/tile/yellow{dir = 1},/obj/effect/turf_decal/tile/yellow{dir = 8},/obj/effect/turf_decal/tile/yellow{dir = 4},/turf/open/indestructible{icon_state = "darkfull"; wet = 8},/area/ruin/powered/clownplanet)
+"aZ" = (/obj/structure/disposalpipe/trunk{dir = 4},/obj/structure/disposaloutlet{dir = 8},/turf/open/floor/plating,/area/ruin/powered/clownplanet)
+"ba" = (/obj/item/bikehorn,/obj/structure/disposalpipe/segment{invisibility = 101},/obj/effect/turf_decal/tile/yellow,/obj/effect/turf_decal/tile/yellow{dir = 1},/obj/effect/turf_decal/tile/yellow{dir = 8},/obj/effect/turf_decal/tile/yellow{dir = 4},/turf/open/indestructible{icon_state = "darkfull"; wet = 8},/area/ruin/powered/clownplanet)
+"bb" = (/obj/structure/disposalpipe/segment{dir = 4; invisibility = 101},/obj/effect/turf_decal/tile/red,/obj/effect/turf_decal/tile/red{dir = 8},/obj/effect/turf_decal/tile/red{dir = 4},/obj/effect/turf_decal/tile/red{dir = 1},/turf/open/indestructible{icon_state = "darkfull"; wet = 8},/area/ruin/powered/clownplanet)
+"bc" = (/obj/effect/decal/cleanable/pie_smudge,/obj/effect/turf_decal/tile/yellow,/obj/effect/turf_decal/tile/yellow{dir = 1},/obj/effect/turf_decal/tile/yellow{dir = 8},/obj/effect/turf_decal/tile/yellow{dir = 4},/turf/open/indestructible{icon_state = "darkfull"; wet = 8},/area/ruin/powered/clownplanet)
+"bd" = (/obj/structure/disposalpipe/segment{dir = 4; invisibility = 101},/turf/open/indestructible{icon_state = "white"},/area/ruin/powered/clownplanet)
+"be" = (/obj/structure/disposalpipe/segment{dir = 6},/obj/effect/decal/cleanable/dirt,/obj/effect/turf_decal/tile/yellow,/obj/effect/turf_decal/tile/yellow{dir = 1},/obj/effect/turf_decal/tile/yellow{dir = 8},/obj/effect/turf_decal/tile/yellow{dir = 4},/turf/open/indestructible{icon_state = "darkfull"; wet = 8},/area/ruin/powered/clownplanet)
+"bf" = (/obj/structure/disposalpipe/segment{dir = 4; invisibility = 101},/obj/structure/table,/obj/item/paper/crumpled/bloody/ruins/lavaland/clown_planet/escape,/obj/item/pen/fourcolor,/turf/open/indestructible{icon_state = "white"},/area/ruin/powered/clownplanet)
+"bg" = (/obj/structure/disposalpipe/segment{dir = 4; invisibility = 101},/obj/structure/table,/obj/item/flashlight/lamp/bananalamp,/turf/open/indestructible{icon_state = "white"},/area/ruin/powered/clownplanet)
+"bh" = (/obj/structure/disposalpipe/segment{dir = 10},/obj/effect/decal/cleanable/pie_smudge,/obj/effect/turf_decal/tile/yellow,/obj/effect/turf_decal/tile/yellow{dir = 1},/obj/effect/turf_decal/tile/yellow{dir = 8},/obj/effect/turf_decal/tile/yellow{dir = 4},/turf/open/indestructible{icon_state = "darkfull"; wet = 8},/area/ruin/powered/clownplanet)
+"bi" = (/obj/structure/disposalpipe/segment{dir = 4; invisibility = 101},/obj/item/pickaxe,/turf/open/indestructible{icon_state = "white"},/area/ruin/powered/clownplanet)
+"bj" = (/obj/structure/disposalpipe/segment{dir = 6},/turf/open/indestructible{icon_state = "white"},/area/ruin/powered/clownplanet)
+"bk" = (/obj/structure/disposalpipe/segment{dir = 10},/turf/open/indestructible{icon_state = "white"},/area/ruin/powered/clownplanet)
+"bl" = (/obj/structure/disposalpipe/segment{dir = 4; invisibility = 101},/obj/machinery/light/small{brightness = 3; dir = 8},/turf/open/indestructible{icon_state = "white"},/area/ruin/powered/clownplanet)
+"bm" = (/obj/structure/disposalpipe/segment{dir = 4; invisibility = 101},/turf/open/indestructible{icon_state = "light_on"},/area/ruin/powered/clownplanet)
+"bn" = (/obj/structure/disposalpipe/segment{dir = 4; invisibility = 101},/obj/machinery/light/small{dir = 4},/turf/open/indestructible{icon_state = "white"},/area/ruin/powered/clownplanet)
+"bo" = (/obj/structure/disposalpipe/segment{invisibility = 101},/obj/machinery/light/small{brightness = 3; dir = 8},/turf/open/indestructible{icon_state = "white"},/area/ruin/powered/clownplanet)
+"bp" = (/turf/open/indestructible{icon_state = "light_on"},/area/ruin/powered/clownplanet)
+"bq" = (/obj/structure/disposalpipe/segment{dir = 5},/turf/open/indestructible{icon_state = "white"},/area/ruin/powered/clownplanet)
+"br" = (/obj/structure/disposalpipe/segment{dir = 9},/obj/machinery/light/small{dir = 4},/turf/open/indestructible{icon_state = "white"},/area/ruin/powered/clownplanet)
+"bs" = (/obj/machinery/light{dir = 4},/turf/open/floor/plating/asteroid/basalt/lava_land_surface,/area/ruin/powered/clownplanet)
+"bt" = (/turf/closed/mineral/bananium,/area/ruin/powered/clownplanet)
+"bu" = (/obj/item/pickaxe,/turf/open/indestructible{icon_state = "white"},/area/ruin/powered/clownplanet)
+"bv" = (/turf/open/indestructible{icon_state = "white"},/area/ruin/powered/clownplanet)
+"bw" = (/obj/structure/disposalpipe/segment{dir = 6},/obj/effect/turf_decal/tile/red,/obj/effect/turf_decal/tile/red{dir = 8},/obj/effect/turf_decal/tile/red{dir = 4},/obj/effect/turf_decal/tile/red{dir = 1},/turf/open/indestructible{icon_state = "darkfull"; wet = 8},/area/ruin/powered/clownplanet)
+"bx" = (/obj/structure/disposalpipe/segment{dir = 10},/obj/effect/decal/cleanable/dirt,/obj/effect/turf_decal/tile/yellow,/obj/effect/turf_decal/tile/yellow{dir = 1},/obj/effect/turf_decal/tile/yellow{dir = 8},/obj/effect/turf_decal/tile/yellow{dir = 4},/turf/open/indestructible{icon_state = "darkfull"; wet = 8},/area/ruin/powered/clownplanet)
+"by" = (/obj/structure/disposalpipe/segment{dir = 5},/turf/open/floor/plating,/area/ruin/powered/clownplanet)
+"bz" = (/obj/item/bikehorn,/obj/structure/disposalpipe/segment{dir = 10},/obj/effect/turf_decal/tile/yellow,/obj/effect/turf_decal/tile/yellow{dir = 1},/obj/effect/turf_decal/tile/yellow{dir = 8},/obj/effect/turf_decal/tile/yellow{dir = 4},/turf/open/indestructible{icon_state = "darkfull"; wet = 8},/area/ruin/powered/clownplanet)
+"bA" = (/obj/structure/disposalpipe/segment{dir = 9},/turf/open/indestructible{icon_state = "white"},/area/ruin/powered/clownplanet)
+"bB" = (/obj/machinery/light{dir = 8},/obj/effect/mapping_helpers/no_lava,/turf/open/floor/plating/asteroid/basalt/lava_land_surface,/area/ruin/powered/clownplanet)
+"bC" = (/obj/effect/mapping_helpers/no_lava,/turf/open/chasm/lavaland,/area/lavaland/surface/outdoors/explored)
+"bD" = (/obj/effect/decal/cleanable/cobweb,/obj/effect/turf_decal/tile/red,/obj/effect/turf_decal/tile/red{dir = 8},/obj/effect/turf_decal/tile/red{dir = 4},/obj/effect/turf_decal/tile/red{dir = 1},/turf/open/indestructible{icon_state = "darkfull"; wet = 8},/area/ruin/powered/clownplanet)
+"bE" = (/obj/structure/disposalpipe/segment,/obj/effect/turf_decal/tile/yellow,/obj/effect/turf_decal/tile/yellow{dir = 1},/obj/effect/turf_decal/tile/yellow{dir = 8},/obj/effect/turf_decal/tile/yellow{dir = 4},/turf/open/indestructible{icon_state = "darkfull"; wet = 8},/area/ruin/powered/clownplanet)
+"bF" = (/obj/effect/decal/cleanable/pie_smudge,/obj/effect/turf_decal/tile/yellow{dir = 4},/obj/effect/turf_decal/tile/yellow{dir = 8},/obj/effect/turf_decal/tile/yellow{dir = 1},/obj/effect/turf_decal/tile/yellow,/turf/open/indestructible{icon_state = "darkfull"; wet = 8},/area/ruin/powered/clownplanet)
+"bG" = (/obj/machinery/disposal/deliveryChute{dir = 1},/obj/structure/disposalpipe/trunk,/turf/open/indestructible{icon_state = "white"},/area/ruin/powered/clownplanet)
+"bH" = (/obj/effect/turf_decal/tile/red,/obj/effect/turf_decal/tile/red{dir = 8},/obj/effect/turf_decal/tile/red{dir = 4},/obj/effect/turf_decal/tile/red{dir = 1},/turf/open/indestructible{icon_state = "darkfull"; wet = 8},/area/ruin/powered/clownplanet)
+"bI" = (/turf/open/indestructible/sound{icon_state = "bananium"; name = "bananium floor"; sound = 'sound/effects/clownstep1.ogg'; wet = 8},/area/ruin/powered/clownplanet)
+"bJ" = (/obj/machinery/light{dir = 1},/obj/effect/turf_decal/tile/red,/obj/effect/turf_decal/tile/red{dir = 8},/obj/effect/turf_decal/tile/red{dir = 4},/obj/effect/turf_decal/tile/red{dir = 1},/turf/open/indestructible{icon_state = "darkfull"; wet = 8},/area/ruin/powered/clownplanet)
+"bK" = (/obj/structure/disposalpipe/junction/yjunction{dir = 1; invisibility = 101},/obj/effect/decal/cleanable/dirt,/obj/effect/turf_decal/tile/yellow,/obj/effect/turf_decal/tile/yellow{dir = 1},/obj/effect/turf_decal/tile/yellow{dir = 8},/obj/effect/turf_decal/tile/yellow{dir = 4},/turf/open/indestructible{icon_state = "darkfull"; wet = 8},/area/ruin/powered/clownplanet)
+"bL" = (/obj/structure/mecha_wreckage/honker,/obj/structure/disposalpipe/segment{dir = 4; invisibility = 101},/turf/open/floor/plating,/area/ruin/powered/clownplanet)
+"bM" = (/obj/effect/decal/cleanable/oil,/obj/structure/disposalpipe/segment{dir = 10},/turf/open/floor/plating,/area/ruin/powered/clownplanet)
+"bN" = (/obj/effect/decal/cleanable/cobweb{icon_state = "cobweb2"},/turf/open/indestructible/sound{icon_state = "bananium"; name = "bananium floor"; sound = 'sound/effects/clownstep1.ogg'; wet = 8},/area/ruin/powered/clownplanet)
+"bO" = (/obj/item/grown/bananapeel{color = "#2F3000"; name = "stealth banana peel"},/obj/effect/mapping_helpers/no_lava,/turf/open/floor/plating/asteroid/basalt/lava_land_surface,/area/lavaland/surface/outdoors/explored)
+"bP" = (/obj/effect/decal/cleanable/dirt,/turf/open/indestructible/sound{icon_state = "bananium"; name = "bananium floor"; sound = 'sound/effects/clownstep1.ogg'; wet = 8},/area/ruin/powered/clownplanet)
+"bQ" = (/obj/effect/mob_spawn/human/corpse/damaged,/obj/effect/decal/cleanable/blood/old,/obj/effect/turf_decal/tile/yellow{dir = 8},/obj/effect/turf_decal/tile/yellow{dir = 1},/obj/effect/turf_decal/tile/yellow,/obj/effect/turf_decal/tile/yellow{dir = 4},/turf/open/indestructible{icon_state = "darkfull"; wet = 8},/area/ruin/powered/clownplanet)
+"bR" = (/obj/structure/disposalpipe/segment{dir = 9},/obj/effect/turf_decal/tile/red,/obj/effect/turf_decal/tile/red{dir = 8},/obj/effect/turf_decal/tile/red{dir = 4},/obj/effect/turf_decal/tile/red{dir = 1},/turf/open/indestructible{icon_state = "darkfull"; wet = 8},/area/ruin/powered/clownplanet)
+"bS" = (/obj/item/reagent_containers/food/drinks/trophy/gold_cup,/obj/structure/table/glass,/turf/open/floor/carpet,/area/ruin/powered/clownplanet)
+"bT" = (/obj/machinery/light/small{dir = 1},/turf/open/floor/carpet,/area/ruin/powered/clownplanet)
+"bU" = (/obj/machinery/disposal/deliveryChute,/obj/structure/disposalpipe/trunk{dir = 1},/turf/open/floor/carpet,/area/ruin/powered/clownplanet)
+"bV" = (/turf/open/floor/carpet,/area/ruin/powered/clownplanet)
+"bW" = (/obj/effect/decal/cleanable/cobweb,/turf/open/indestructible/sound{icon_state = "bananium"; name = "bananium floor"; sound = 'sound/effects/clownstep1.ogg'; wet = 8},/area/ruin/powered/clownplanet)
+"bX" = (/obj/structure/statue/bananium/clown,/turf/open/floor/carpet,/area/ruin/powered/clownplanet)
+"bY" = (/obj/structure/table/glass,/obj/item/grown/bananapeel/bluespace,/turf/open/floor/carpet,/area/ruin/powered/clownplanet)
+"bZ" = (/obj/structure/table/glass,/obj/item/clothing/shoes/clown_shoes/banana_shoes,/turf/open/floor/carpet,/area/ruin/powered/clownplanet)
+"ca" = (/obj/item/coin/bananium,/obj/item/coin/bananium,/obj/item/coin/bananium,/obj/item/coin/bananium,/obj/machinery/light/small{dir = 8},/turf/open/floor/carpet,/area/ruin/powered/clownplanet)
+"cb" = (/obj/item/slime_extract/rainbow,/obj/structure/table/glass,/turf/open/floor/carpet,/area/ruin/powered/clownplanet)
+"cc" = (/obj/item/bikehorn/airhorn,/turf/open/floor/carpet,/area/ruin/powered/clownplanet)
+"cd" = (/obj/structure/table/glass,/obj/item/pneumatic_cannon/pie/selfcharge,/turf/open/floor/carpet,/area/ruin/powered/clownplanet)
+"ce" = (/obj/item/coin/bananium,/obj/item/coin/bananium,/obj/item/coin/bananium,/obj/item/coin/bananium,/obj/machinery/light/small{dir = 4},/turf/open/floor/carpet,/area/ruin/powered/clownplanet)
+"cf" = (/obj/item/bikehorn,/turf/open/indestructible/sound{icon_state = "bananium"; name = "bananium floor"; sound = 'sound/effects/clownstep1.ogg'; wet = 8},/area/ruin/powered/clownplanet)
+"cg" = (/obj/effect/mob_spawn/human/corpse/damaged,/obj/effect/decal/cleanable/blood/old,/turf/open/indestructible/sound{icon_state = "bananium"; name = "bananium floor"; sound = 'sound/effects/clownstep1.ogg'; wet = 8},/area/ruin/powered/clownplanet)
+"ch" = (/obj/machinery/light{dir = 1},/turf/open/indestructible/sound{icon_state = "bananium"; name = "bananium floor"; sound = 'sound/effects/clownstep1.ogg'; wet = 8},/area/ruin/powered/clownplanet)
+"ci" = (/obj/machinery/door/airlock/bananium,/turf/open/indestructible/sound{icon_state = "bananium"; name = "bananium floor"; sound = 'sound/effects/clownstep1.ogg'; wet = 8},/area/ruin/powered/clownplanet)
+"cj" = (/obj/item/bikehorn,/obj/effect/decal/cleanable/dirt,/turf/open/indestructible/sound{icon_state = "bananium"; name = "bananium floor"; sound = 'sound/effects/clownstep1.ogg'; wet = 8},/area/ruin/powered/clownplanet)
+"ck" = (/obj/machinery/light,/turf/open/indestructible/sound{icon_state = "bananium"; name = "bananium floor"; sound = 'sound/effects/clownstep1.ogg'; wet = 8},/area/ruin/powered/clownplanet)
+"cl" = (/obj/machinery/light{dir = 1},/obj/effect/mapping_helpers/no_lava,/turf/open/floor/plating/asteroid/basalt/lava_land_surface,/area/ruin/powered/clownplanet)
+
+(1,1,1) = {"
+aaaaaaaaaaaaaaaaaaaaaaaaababacacacababaaaaaaaaaaaaaaaaaaaaaaaa
+aaaaaaaaaaaaaaaaaaadaeadadafacagacacadadaeadaaaaaaaaaaaaaaaaaa
+aaaaaaaaaaaaahahahahahahahahaiajakahahahahahahahahahaaaaaaaaaa
+aaaaaaaaahahahalalalalalalahamahamahalalalalalalalahahaaaaaaaa
+aaaaaaahahalalalanaoapaqahalamalamalalahaharahahalalahahaaaaaa
+aaaaahahalalanaqasatamasauaoavapawahahahahaxahahahahalahahaaaa
+aaaaahalalahayasasasazasasasasasaAaBaBaCaDaEaFaGaHahalalahaaaa
+aaahahalanaIaEaJaKaJaKaLaEasamaMaCaBaBaCaNaOaCaCaCaPahalahahaa
+aaahalalavauaBaBaCaOaBaBaPasasauaCaBaQaCaOaRaCaOaCaEaSalalahaa
+aaahalapaTasauaOaCaBaBaoayasaUaJaOaCaCaBaBaBaQaCaCaVahaWalahaa
+aaahalaMaXaYasaZaOaOaOaEasbaamauaCaCaCaCaOaObbaOaPasbcaWalahaa
+aaahalapaKasaMaObdbdbdaOaEasayasbeaCaOaObfbgbdaOaEasaFaWalahaa
+aaahalaMbhaJaObdbdbdbibdaOaKasasasaFahbjbdbdbkbjaOaTaSahalahaa
+aaahahalaMaOaOblbdbmbmbnaOaCaKavaJaPahbobpbpbqbrahahahalahahaa
+aabsahahalalahbtbubpbpbvbwbxaGbybzaJbbbAbpbpbvbtahalalahahbBaa
+ababbCahahahbDahbtbvbtahamaAaCaPbEbFahahbtbGbtahbHahahahbCabab
+abbCbCbCahbIbHbJahbHahahaMaBaPaJbKaObLbMahamahbJbHbNahbCbCabbC
+ababbObCahbPbIbHahbHbHbHahahaJbxaGbQahaMbbbRbHbHbIbIahbCbOabab
+ababbCbCahbIbPbIbHbHbHbIahahahamahahbIbIbHahbHbIbIbIahbCbCabab
+abbCbCahahahbPahbIbIbIbIahbSbTbUbVbSahbIbIbIbIbIbIahahahbCbCab
+aabsahahbWbIbIahbIahbIahbXbVbYbVbZbVbXahbIbIbIbIbPbIbIahahbBaa
+aaahahalbIbPbPbPbPbIahahcabVcbcccdbVceahahbPbPbIcfbIbIalahahaa
+aaahalalaWcgbIahbIbIbIbIahbVbVbVbVbVahcgbIbPbPbIbIahbIalalahaa
+aaahalaWalbIbIbIbIbPbIbIchahahciahahchbIbPbPbIahbIbIalaSalahaa
+aaahalaSalaWbIbIcjbPbIahbIbIahbIbIbIbIbIbIbIbIbIbIbIalaWalahaa
+aaahahalalalahbIbPbIbIbIbPbPbPbPbIbIbPbPbIcfahbIahalalalahahaa
+aaaaahalalaWalaWckbIbPbPcjbPbIbIbIbIbPbIbIckahalalaSalalahaaaa
+aaaaahahalalaSalahalalalbIbIbIahbIbIbIalalahalaSaWalalahahaaaa
+aaaaaaahahalalalalaWaWaSalalalalalalalaWaWaWaSalalalahahaaaaaa
+aaaaaaaaahahahalalalalaWaWaWaWaWaWaWaWaSalalalalahahahaaaaaaaa
+aaaaaaaaaaclahahahahalalalalalalalalalalalahahahahclaaaaaaaaaa
+aaaaaaaaaaaaaaaaaaahahahahahahahahahahahahahaaaaaaaaaaaaaaaaaa
+"}


### PR DESCRIPTION
Edited the Clown ruin to remove the honkmother staff so that we can still have the ruin and everything in it, but not break the server. It has been replaced with the auto loading pie cannon.

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Just a simple ruin edit.

## Why It's Good For The Game
Keeps more content in the game for mining, as well as fixing the main issue that there was with the ruin.

## Changelog
:cl:
add: Added new things
add: Added more things
del: Removed old things
tweak: tweaked a few things
balance: rebalanced something
fix: fixed a few things
soundadd: added a new sound thingy
sounddel: removed an old sound thingy
imageadd: added some icons and images
imagedel: deleted some icons and images
spellcheck: fixed a few typos
code: changed some code
refactor: refactored some code
config: changed some config setting
admin: messed with admin stuff
server: something server ops should know
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
